### PR TITLE
Fixing Streamlit deployment issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-streamlit==1.25.0
+streamlit>=1.30.0
 streamlit-extras


### PR DESCRIPTION
The issue with deploying the streamlit on cloud is due to version incompatibility, using a more recent version fixed it. 